### PR TITLE
Add a color field to the Answer model

### DIFF
--- a/decisiontree/forms/forms.py
+++ b/decisiontree/forms/forms.py
@@ -11,7 +11,7 @@ class AnswerCreateUpdateForm(TenancyModelForm):
 
     class Meta:
         model = models.Answer
-        fields = ['name', 'type', 'answer', 'description']
+        fields = ['name', 'type', 'answer', 'color', 'description']
 
 
 class AnswerSearchForm(forms.Form):

--- a/decisiontree/migrations/0004_answer_color.py
+++ b/decisiontree/migrations/0004_answer_color.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import colorful.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('decisiontree', '0003_auto_20150211_1345'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='answer',
+            name='color',
+            field=colorful.fields.RGBColorField(default='#000000'),
+            preserve_default=True,
+        ),
+    ]

--- a/decisiontree/models.py
+++ b/decisiontree/models.py
@@ -5,6 +5,8 @@ from django.db import models
 from django.db.models import Q
 from django.utils.encoding import python_2_unicode_compatible
 
+from colorful.fields import RGBColorField
+
 
 @python_2_unicode_compatible
 class Question(models.Model):
@@ -96,6 +98,7 @@ class Answer(models.Model):
     name = models.CharField(max_length=30, unique=True)
     type = models.CharField(max_length=1, choices=ANSWER_TYPES)
     answer = models.CharField(max_length=160)
+    color = RGBColorField(default=u"#000000")
     description = models.CharField(max_length=100, blank=True)
 
     def __str__(self):

--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,8 @@ setup(
         'Operating System :: OS Independent',
     ),
     zip_safe=False,
-    install_requires=['RapidSMS>=0.19.0'],
+    install_requires=[
+        'RapidSMS>=0.19.0',
+        'django-colorful>=1.0.1',
+    ],
 )


### PR DESCRIPTION
This uses [django-colorful](https://github.com/charettes/django-colorful) to add a color field to the Answer model.

Screenshot:

![image](https://cloud.githubusercontent.com/assets/4413/6652034/c943c506-ca35-11e4-978f-02657948b5f2.png)

Addresses #26 
