### PR TITLE
Make character counter a bit more robust

### DIFF
--- a/decisiontree/static/tree/javascripts/decisiontree.js
+++ b/decisiontree/static/tree/javascripts/decisiontree.js
@@ -10,21 +10,29 @@ $(function () {
   }
   $('.counterField textarea').maxlength(
     {max: $('#id_max_length').val(),
-     truncate: false,
-     onFull: function(overflowing){
-       if (!overflowing) {
-         clearNotifications();
-         // enable the submit button
-         $(':button').removeAttr('disabled');
-       } else {
-         clearNotifications();
-         addNotification("error", "Message too long.");
-         // disable the submit button
-         $(':button').attr('disabled', 'disabled');
-       }
-     }
+     truncate: false
     });
   $('#id_max_length').change(function(event){
     $('.counterField textarea').maxlength('option', 'max', $('#id_max_length').val());
+    // trigger a change event on the textarea
+    $('.counterField textarea').change();
+  });
+  // On any change to the textarea, check the character count
+  $('.counterField textarea').on('change keyup paste', function(event){
+    submit = $('#submit-button')[0];
+    if (this.value.length > $('#id_max_length').val()) {
+      // update the notification, only if this is a change
+      if (!submit.disabled) {
+        clearNotifications();
+        addNotification("error", "Message too long.");
+        submit.disabled = true;
+      }
+    } else {
+      // update the notification, only if this is a change
+      if (submit.disabled) {
+        clearNotifications();
+        submit.disabled = false;
+      }
+    }
   });
 });

--- a/decisiontree/templates/tree/questions/create_update.html
+++ b/decisiontree/templates/tree/questions/create_update.html
@@ -43,7 +43,7 @@
     </div>
 
     <div class="form-actions">
-      <button type="submit" class="btn btn-primary">
+      <button id="submit-button" type="submit" class="btn btn-primary">
         {% if object %}{% trans "Update" %}{% else %}{% trans "Create" %} {{ view.model|verbose_name|title }}{% endif %}
       </button>
       <a href="{{ cancellation_url }}" class="btn">{% trans "Cancel" %}</a>


### PR DESCRIPTION
Prior version would only re-enable the submit button if text length was
exactly equal to the max length, which didn't work if you quickly
deleted characters (bypassing the maxlength value) or pasted shorter
text into the field.
